### PR TITLE
日本語のコメントを許容する

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -17,6 +17,9 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/AsciiComments:
+  Enabled: false
+
 Metrics/MethodLength:
   CountComments: false
   Max: 20


### PR DESCRIPTION
無駄にコメントを書かない、というのが大前提ですが、どうしてもコメントが必要な場合は無理に英語にしなくても良いと考えます。