### PR TITLE
後置if/unlessを強制しない

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -20,6 +20,9 @@ Style/ClassAndModuleChildren:
 Style/AsciiComments:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Metrics/MethodLength:
   CountComments: false
   Max: 20


### PR DESCRIPTION
後置if/unlessは機械的に適用するのではなく、可読性も考慮した上で使う/使わないを判断するのが良いと考えます。

参考 [【Ruby】乱用厳禁！？後置ifで書くとかえって読みづらくなるケース \- Qiita](https://qiita.com/jnchito/items/4e47559a4c821474233a)