### PR TITLE
Specify rubocop version to avoid runtime error

### DIFF
--- a/rubocop-fjord.gemspec
+++ b/rubocop-fjord.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '>= 1.0'
   spec.add_dependency 'rubocop-performance'
 
   spec.add_development_dependency 'bundler', '~> 1.17'


### PR DESCRIPTION
rubocop 0.88.0 のような古いバージョンのrubocopで動かすと実行時エラーが発生するという報告があったため、バージョンを1.0以上に指定しました。