### PR TITLE
bin/**/* のファイルを検査対象から除外する

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'db/schema.rb'
     - 'storage/**/*'
     - 'tmp/**/*'
+    - 'bin/**/*'
 
 Metrics/MethodLength:
   Exclude:


### PR DESCRIPTION
直接修正する場所ではないため、除外した方が良さそうと考えました。