### PR TITLE
テスト系ファイルを無視する設定追加

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -30,3 +30,11 @@ Metrics/CyclomaticComplexity:
 
 Metrics/AbcSize:
   Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - test/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*


### PR DESCRIPTION
テスト系でLength系のチェックは不要と思うので、
test-unit/minitest系と rspec 両方無視できるように設定しました。