### PR TITLE
メソッドの長さの設定とテストケースの除外設定を両立する

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -24,6 +24,8 @@ Style/AsciiComments:
 Metrics/MethodLength:
   CountComments: false
   Max: 20
+  Exclude:
+    - test/**/*
 
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -32,10 +34,6 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/ClassLength:
-  Exclude:
-    - test/**/*
-
-Metrics/MethodLength:
   Exclude:
     - test/**/*
 


### PR DESCRIPTION
現在、24行目の「メソッドの行数を20行以内に指定する設定」が38行目の「テストでは行数制限を除外する設定」に上書きされて無効になってしまっているようです。

以下は実行結果で出ている警告です。
```
$ rubocop
/Users/ユーザー名/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rubocop-fjord-0.2.1/config/rubocop.yml:24: `Metrics/MethodLength` is concealed by line 38
```

二つの設定を一つにして両方動くように設定しました。