### PR TITLE
Update TargetRubyVersion

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
   NewCops: disable
 
 Performance:


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/blob/main/Gemfile#L6 も Ruby プラクティスも Ruby 3.1 を使っているので、RuboCopの解析対象バージョンを3.1に上げます。