### PR TITLE
未使用の引数があった場合の自動修正を無効化する

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -40,3 +40,6 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+
+Lint/UnusedMethodArgument:
+  AutoCorrect: false


### PR DESCRIPTION
https://bootcamp.fjord.jp/pages/rubocop-is-not-perfect で注意した内容です。
そもそもの話として、自動修正を無効化すれば、適切な修正方法に自ずと気付いてもらえるのでは？と思ってこうしてみました。

とはいえ、「盲目的にRuboCopを適用しない」とか「コミット前のセルフレビューはしよう」ということを痛感してもらうために、あえて自動修正させる、という考え方もあるので、採用するかどうかは議論の余地があると思います。