### PR TITLE
BlockLengthはtestの場合も考慮しない(Railsのテストを考慮)

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -40,6 +40,7 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - test/**/*
 
 Lint/UnusedMethodArgument:
   AutoCorrect: false


### PR DESCRIPTION
Railsの

```ruby
test 'foo bar' do
  # ...
end
```

スタイルのテストがRuboCopの警告に引っかかりやすいのでtestディレクトリに関してはブロックの長さはチェックしないようにしたいです。