### PR TITLE
Set SuggestExtensions: false

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   TargetRubyVersion: 3.1
   NewCops: disable
+  SuggestExtensions: false
 
 Performance:
   Exclude:


### PR DESCRIPTION
Latest Rubocop shows following message every time. This PR will opt out it.

```
$ rubocop
Inspecting 38 files
......................................

38 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```