### PR TITLE
Suppress warnings about plugin migration

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rails
 
 AllCops:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:


### PR DESCRIPTION
The plugin system was introduced in RuboCop 1.72.

* config/rails.yml (plugins): Replace from "require".
* config/rubocop.yml (plugins): Replace from "require".