### PR TITLE
Exclude extra schema.rb files for Rails 8

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'config.ru'
     - 'node_modules/**/*'
     - 'db/migrate/*'
-    - 'db/schema.rb'
+    - 'db/*schema.rb'
     - 'storage/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'


### PR DESCRIPTION
Rails 8 generates the following schema.rb files:

- db/cable_schema.rb
- db/cache_schema.rb
- db/queue_schema.rb

This PR excludes them for inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * RuboCopの除外パターンが拡張され、`db`ディレクトリ内の全ての`schema.rb`で終わるファイルが除外対象になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->